### PR TITLE
chore: fix release recipe to create artifacts dir

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ assert-no-pending-changes:
 assert-no-pending-changes:
     [ -z "$(git status --porcelain)" ]
 
-release: (assert-branch "main") assert-no-pending-changes && push-release
+release: (assert-branch "main") assert-no-pending-changes artifacts-dir && push-release
     git pull
     git-cliff --bump --output CHANGELOG.md
     git-cliff --bump --unreleased --strip header --output artifacts/RELEASE-NOTES.md


### PR DESCRIPTION
This pull request includes a small but important change to the `justfile`. The change ensures that the `release` command now includes the `artifacts-dir` step, which is necessary for the release process.

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L55-R55): Modified the `release` command to include the `artifacts-dir` step for proper release preparation.